### PR TITLE
added healthcheck to loadbalander backend

### DIFF
--- a/traefik_dynamic.yml
+++ b/traefik_dynamic.yml
@@ -23,6 +23,9 @@ http:
           - url: "http://web:2022/"
     svcBackend:
       loadBalancer:
+        healthCheck:
+          path: /api/tasks
+          interval: 5s
         servers:
           - url: "http://backend1:8080"
           - url: "http://backend2:8080"


### PR DESCRIPTION
Takes now 5s for interval checking and 5s to determine, if container is dead